### PR TITLE
Pass namespace from infra to apps. NAMESPACE is defined in infra as f…

### DIFF
--- a/apps.tf
+++ b/apps.tf
@@ -14,6 +14,7 @@ module "apps" {
   ad_aws_ssm_document_name        = "${module.ad.ad_aws_ssm_document_name}"
   #ad_writer_instance_profile_name = "${module.ad.ad_writer_instance_profile_name}"
   naming_suffix                   = "${local.naming_suffix}"
+  namespace                       = "${var.NAMESPACE}"
 
   s3_bucket_name = {
     archive_log                = "s3-dq-log-archive-bucket-${var.NAMESPACE}"


### PR DESCRIPTION
…or example test or notprod. naming_suffix is defined as test-dq or notprod-dq in infra, and apps-test-dq or apps-notprod-dq in apps. Bucket names end in NAMESPACE rather than naming_suffix. Therefore to correctly reference bucket names in pipelines we need to pass namespace to apps so it can pass it to the pipelines.